### PR TITLE
Update playbook.yml

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -122,6 +122,11 @@
     shell: vagrant plugin install vagrant-libvirt
   - name: vagrant-preload - install
     shell: vagrant plugin install vagrant-reload
+  - name: vagrant volume_cache setup fix
+    lineinfile:
+      path: Vagrantfile
+      regexp: "^      domain.volume_cache = 'none'$"
+      line: "      domain.disk_driver :cache => 'none'" 
   - name: vagrant - cleanup VM
     shell: vagrant destroy -f
   - name: vagrant - provision VM

--- a/playbook.yml
+++ b/playbook.yml
@@ -103,6 +103,21 @@
       - libvirt-dev
       - zlib1g-dev
       - ruby-dev
+  - name: Add an apt signing key for vagrant-repository
+    apt_key:
+      url: https://apt.releases.hashicorp.com/gpg
+  - name: vagrant-repository - install
+    apt_repository:
+      repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+  - name: vargant - remove old vagrant installed by role crivetimihai.virtualization.vagrant
+    apt:
+      pkg:
+      - vagrant
+      state: absent
+  - name: vargant - install the latest version
+    apt:
+      pkg:
+      - vagrant
   - name: vagrant-libvirt - install
     shell: vagrant plugin install vagrant-libvirt
   - name: vagrant-preload - install


### PR DESCRIPTION
Fix problem with old vagrant version hardcoded at crivetimihai.virtualization.vagrant/roles/vagrant/vars/main.yml The problem blocks installation of nokogiri with following error:nokogiri requires Ruby version < 3.1.dev, >= 2.5" and can't be bypassed by install specific gem version like "gem install nokogiri -v 1.10.10"