### PR TITLE
Updated default network to AUTO instead of BLOXBERG

### DIFF
--- a/node/config.py
+++ b/node/config.py
@@ -64,7 +64,7 @@ mumbai_gas_price_measure = os.environ.get('MUMBAI_GAS_PRICE_MEASURE')
 mumbai_task_execution_price_default = os.environ.get('MUMBAI_TASK_EXECUTION_PRICE_DEFAULT');
 
 
-network_default = "BLOXBERG"
+network_default = "AUTO"
 task_price_default = 3
 network = None
 heart_beat_address = None


### PR DESCRIPTION
If the node was installed before release [v0.9.0](https://github.com/ethernity-cloud/mvp-pox-node/releases/tag/v0.9.0)  there is no network specified in the configuration, therefore the default network is set to BLOXBERG.

This is not the intended behavior. The default network should be AUTO.