### PR TITLE
Ubuntu22 ansible fix

### DIFF
--- a/roles/install_node/tasks/debian_22.yml
+++ b/roles/install_node/tasks/debian_22.yml
@@ -33,7 +33,6 @@
        - genisoimage
        - cpu-checker  
     state: present
-    allow_downgrade: true
 - name:  Ubuntu 22.04 | vagrant add key  
   apt_key:
     url: https://apt.releases.hashicorp.com/gpg

--- a/roles/uoi-io.libvirt/tasks/main.yml
+++ b/roles/uoi-io.libvirt/tasks/main.yml
@@ -8,18 +8,18 @@
     - libvirt-install
     - libvirt-config
 
-- include: firewall.yml
+- include_tasks: firewall.yml
   when: libvirt_firewalld is defined and
         libvirt_firewalld
   tags: [ libvirt, libvirt-firewalld ]
 
-- include: selinux.yml
+- include_tasks: selinux.yml
   when: libvirt_selinux is defined and
         libvirt_selinux
   tags: [ libvirt, libvirt-selinux ]
 
-- include: install.yml
+- include_tasks: install.yml
   tags: [ libvirt, libvirt-install ]
 
-- include: config.yml
+- include_tasks: config.yml
   tags: [ libvirt, libvirt-config ]


### PR DESCRIPTION
* replaced "include" with "include_task" because ansible decommissioned the option;
* removed allow_downgrade option for qemu in ubuntu 22.04 because of some installation issues - "Unsupported parameters for (apt);