### PR TITLE
IPFS pin retention controls + ESR state replication

### DIFF
--- a/node/config.py
+++ b/node/config.py
@@ -87,6 +87,28 @@ image_registry_abi_filepath = base_path / 'image_registry.abi'
 heart_beat_abi_filepath = base_path / 'heart_beat.abi'
 uuid_filepath = Path(expanduser("~")) / "opt/etny/node/UUID"
 
+# --- Enclave State Registry (ESR) ------------------------------------------
+# Enclaves publish an IPFS CID of their encrypted state to this registry. Nodes
+# replicate that state by pinning the CIDs locally, so a dApp's state survives
+# any single node going away.
+esr_abi_filepath = base_path / 'esr.abi'
+# Canonical deployments, keyed by network name as it appears in networks.ini.
+# "" (or an absent entry) means ESR is not deployed on that network and state
+# replication is simply skipped there.
+#
+# Bloxberg mainnet and testnet are the SAME CHAIN (both chainId 8995), separated
+# by different protocol contracts, so both use the one deployment.
+esr_contract_addresses = {
+    "BLOXBERG_MAINNET": os.environ.get('ESR_CONTRACT_ADDRESS', "0x4f6c0Ae54567CAeD372d265fEF412C2B5ed1302A"),
+    "BLOXBERG_TESTNET": os.environ.get('ESR_CONTRACT_ADDRESS', "0x4f6c0Ae54567CAeD372d265fEF412C2B5ed1302A"),
+}
+# How far back to scan for StateCommitted events on the first pass, in blocks.
+# After that the node continues from the last block it processed.
+esr_scan_lookback_blocks = int(os.environ.get('ESR_SCAN_LOOKBACK_BLOCKS', 50_000))
+# Keep pinning replicated state only while at least this much free disk (in GB)
+# remains, so replication can never fill the disk the node needs to run tasks.
+esr_min_free_storage_gb = float(os.environ.get('ESR_MIN_FREE_STORAGE_GB', 10))
+
 # logger
 logger = logging.getLogger("ETNY NODE")
 handler = logging.handlers.RotatingFileHandler('/var/log/etny-node.log', maxBytes=2048000, backupCount=5)

--- a/node/config.py
+++ b/node/config.py
@@ -24,6 +24,16 @@ ipfs_swarm_default = os.environ.get('IPFS_SWARM', "/dns4/ipfs.ethernity.cloud/tc
 ipfs_connect_url_default = os.environ.get('IPFS_CONNECT_URL', "/ip4/127.0.0.1/tcp/5001/http")
 ipfs_timeout_default = int(os.environ.get('IPFS_TIMEOUT', 30))
 ipfs_gateway_url_default=os.environ.get('IPFS_REMOTE_URL', 'https://ipfs.io')
+# How long a locally pinned IPFS object is kept before the periodic cleanup
+# unpins and removes it. Objects the node still needs are exempt regardless of
+# age: the trustedzone images, and any CID that is still the CURRENT ESR state
+# for some enclave/key (only superseded state versions expire).
+# 0 disables age-based cleanup entirely.
+ipfs_pin_retention_days_default = float(os.environ.get('IPFS_PIN_RETENTION_DAYS', 7))
+# Minimum minutes between cleanup runs. The cleanup is triggered from the
+# order-processing loop (the same place that calls the heartbeat), so this
+# throttles it to at most once per interval instead of once per order.
+ipfs_cleanup_interval_minutes_default = float(os.environ.get('IPFS_CLEANUP_INTERVAL_MINUTES', 60))
 skip_integration_test = strtobool(os.environ.get('SKIP_INTEGRATION_TEST', "False"))
 kubo_url_default = os.environ.get('KUBO_URL')
 kubo_version_default =  os.environ.get('KUBO_VERSION')

--- a/node/esr.abi
+++ b/node/esr.abi
@@ -1,0 +1,71 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true,  "internalType": "address", "name": "enclave", "type": "address" },
+      { "indexed": true,  "internalType": "bytes32", "name": "key",     "type": "bytes32" },
+      { "indexed": false, "internalType": "string",  "name": "cid",     "type": "string"  },
+      { "indexed": false, "internalType": "uint256", "name": "version", "type": "uint256" }
+    ],
+    "name": "StateCommitted",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyCID",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "expected", "type": "uint256" },
+      { "internalType": "uint256", "name": "actual",   "type": "uint256" }
+    ],
+    "name": "VersionMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "key",             "type": "bytes32" },
+      { "internalType": "string",  "name": "newCID",          "type": "string"  },
+      { "internalType": "uint256", "name": "expectedVersion", "type": "uint256" }
+    ],
+    "name": "commit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "enclave", "type": "address" },
+      { "internalType": "bytes32", "name": "key",     "type": "bytes32" }
+    ],
+    "name": "exists",
+    "outputs": [ { "internalType": "bool", "name": "", "type": "bool" } ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "enclave", "type": "address" },
+      { "internalType": "bytes32", "name": "key",     "type": "bytes32" }
+    ],
+    "name": "getState",
+    "outputs": [
+      { "internalType": "string",  "name": "cid",       "type": "string"  },
+      { "internalType": "uint256", "name": "version",   "type": "uint256" },
+      { "internalType": "uint64",  "name": "updatedAt", "type": "uint64"  }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "enclave", "type": "address" },
+      { "internalType": "bytes32", "name": "key",     "type": "bytes32" }
+    ],
+    "name": "getVersion",
+    "outputs": [ { "internalType": "uint256", "name": "", "type": "uint256" } ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/node/etny-node.py
+++ b/node/etny-node.py
@@ -137,6 +137,29 @@ class EtnyPoXNode:
         self.__heart_beat = self.__w3.eth.contract(
             address=self.__w3.to_checksum_address(self.__network_config.heartbeat_contract_address),
             abi=self.__heart_beat_abi)
+
+        # Enclave State Registry (optional): only wired when this network has a
+        # deployment. Absent => state replication is skipped entirely, so a
+        # network without an ESR behaves exactly as before.
+        self.__esr = None
+        self.__esr_last_block = 0
+        try:
+            esr_address = (config.esr_contract_addresses.get(self.__network_config.name) or "").strip()
+            if esr_address:
+                with open(config.esr_abi_filepath) as f:
+                    esr_abi = f.read()
+                self.__esr = self.__w3.eth.contract(
+                    address=self.__w3.to_checksum_address(esr_address),
+                    abi=esr_abi)
+                logger.info(f"Enclave State Registry: {esr_address}")
+            else:
+                logger.info(f"No Enclave State Registry deployed on {self.__network_config.name}; state replication disabled")
+        except Exception as e:
+            # Never let ESR wiring stop the node from starting -- it is an
+            # add-on to replication, not part of task execution.
+            self.__esr = None
+            logger.warning(f"Could not initialise the Enclave State Registry: {e}")
+
         self.__nonce = self.__w3.eth.get_transaction_count(self.__address)
         self.__dprequest = 0
         self.__order_id = 0
@@ -274,6 +297,115 @@ class EtnyPoXNode:
                 logger.error(f"Failed to copy '{src}' to '{dest}': {e}")
        
 
+    @staticmethod
+    def __looks_like_cid(value):
+        """True for values that plausibly are IPFS CIDs.
+
+        The ESR stores the pointer as an unvalidated string, so the live
+        registry does contain non-CID entries (a 0x-prefixed digest, for
+        instance). Filtering here keeps them out of pin/add, which would
+        otherwise error on every cleanup pass.
+
+        CIDv0 is 46 chars starting "Qm"; CIDv1 is base32 starting "b". Anything
+        0x-prefixed is definitely not a CID.
+        """
+        cid = (value or "").strip()
+        if not cid or cid.startswith("0x"):
+            return False
+        if cid.startswith("Qm") and len(cid) == 46:
+            return True
+        if cid.startswith("b") and len(cid) >= 46 and cid.islower():
+            return True
+        return False
+
+    def __esr_current_state_cids(self):
+        """CIDs that are the CURRENT state for some enclave/key in the registry.
+
+        Scans StateCommitted events, then confirms each (enclave, key) against
+        the contract's live getState. Confirming matters: the newest event we
+        happened to see is not necessarily the newest commit, and pinning
+        decisions must follow the chain, not our scan window.
+
+        Returns a set of CIDs, empty when ESR is unavailable for any reason --
+        an empty set means "protect nothing extra", never "unpin everything".
+        """
+        cids = set()
+        if self.__esr is None:
+            return cids
+        try:
+            latest_block = self.__w3.eth.block_number
+            from_block = self.__esr_last_block or max(0, latest_block - config.esr_scan_lookback_blocks)
+            logs = self.__esr.events.StateCommitted().get_logs(
+                fromBlock=from_block, toBlock=latest_block)
+
+            # Deduplicate to the (enclave, key) pairs seen; the current CID for
+            # each comes from the contract below.
+            pairs = {(l['args']['enclave'], l['args']['key']) for l in logs}
+            for enclave, key in pairs:
+                try:
+                    time.sleep(self.__network_config.rpc_delay / 1000)
+                    cid, version, _updated_at = self.__esr.caller().getState(enclave, key)
+                    # The contract stores the CID as a free-form string and does
+                    # not validate it, so entries that are not CIDs do occur on
+                    # the live registry (e.g. a 0x… hex digest). Only pin things
+                    # that actually look like an IPFS CID; handing anything else
+                    # to pin/add just produces errors on every cleanup pass.
+                    if version and self.__looks_like_cid(cid):
+                        cids.add(cid)
+                except Exception as e:
+                    self.logger.debug(f"ESR getState failed for {enclave}/{key.hex()}: {e}")
+
+            self.__esr_last_block = latest_block
+        except Exception as e:
+            self.logger.warning(f"ESR state scan failed: {e}")
+            return set()
+        return cids
+
+    def __replicate_esr_state(self):
+        """Pin the current ESR state of every enclave, while disk allows.
+
+        Any node holding a state CID keeps that dApp's state available, so a
+        dApp does not depend on the single node that produced it. Bounded by
+        free disk (ESR_MIN_FREE_STORAGE_GB) so replication can never crowd out
+        the storage the node needs to run tasks -- the node stops pinning new
+        state rather than filling up.
+
+        Never raises: replication is best-effort and must not disturb order
+        processing.
+        """
+        if self.__esr is None:
+            return set()
+        try:
+            current = self.__esr_current_state_cids()
+            if not current:
+                return current
+
+            pinned = 0
+            for cid in current:
+                free_gb = HardwareInfoProvider.get_free_storage()
+                if free_gb < config.esr_min_free_storage_gb:
+                    self.logger.warning(
+                        f"Free storage {free_gb}GB is below ESR_MIN_FREE_STORAGE_GB "
+                        f"({config.esr_min_free_storage_gb}GB); stopping state replication for this round"
+                    )
+                    break
+                try:
+                    if not self.storage.is_pinned(cid):
+                        self.storage.pin_add(cid)
+                        pinned += 1
+                    # Refresh the cache timestamp either way, so a CID that is
+                    # still current is never aged out by the retention sweep.
+                    self.ipfs_cache.add(cid)
+                except Exception as e:
+                    self.logger.debug(f"Could not pin ESR state {cid}: {e}")
+
+            if pinned:
+                self.logger.info(f"Replicated {pinned} ESR state object(s)")
+            return current
+        except Exception as e:
+            self.logger.warning(f"ESR state replication skipped: {e}")
+            return set()
+
     def __maybe_clear_ipfs_cache(self):
         """Run the pin cleanup at most once per configured interval.
 
@@ -339,6 +471,15 @@ class EtnyPoXNode:
                 )
                 self.__last_ipfs_cleanup_at = time.time()
                 return
+
+        # Replicate current ESR state and protect it from expiry. Only the CIDs
+        # that are STILL the current version for some enclave/key are kept --
+        # superseded versions age out like anything else, so a dApp never loses
+        # live state while stale revisions are still reclaimed.
+        try:
+            keep_hashes.extend(self.__replicate_esr_state())
+        except Exception as e:
+            logger.warning(f"ESR replication skipped during cleanup: {e}")
 
         retention_hours = retention_seconds / 3600
         removed = 0

--- a/node/etny-node.py
+++ b/node/etny-node.py
@@ -227,6 +227,10 @@ class EtnyPoXNode:
            self.__run_integration_test()
 
 
+        # Tracks when the pin cleanup last ran, so __maybe_clear_ipfs_cache can
+        # throttle the periodic sweep. Set before the first run so the attribute
+        # always exists.
+        self.__last_ipfs_cleanup_at = 0
         self.__clear_ipfs_cache()
         reset_task_running_on()
 
@@ -270,52 +274,101 @@ class EtnyPoXNode:
                 logger.error(f"Failed to copy '{src}' to '{dest}': {e}")
        
 
+    def __maybe_clear_ipfs_cache(self):
+        """Run the pin cleanup at most once per configured interval.
+
+        Cleanup used to happen only in __init__, so a node that stayed up for
+        weeks never reclaimed anything until it was restarted. This is called
+        from the order-processing loop (alongside the heartbeat) and throttled by
+        IPFS_CLEANUP_INTERVAL_MINUTES so it costs one timestamp comparison per
+        order rather than a full sweep.
+
+        Never raises: reclaiming disk must not be able to interrupt order
+        processing.
+        """
+        try:
+            interval = float(getattr(config, 'ipfs_cleanup_interval_minutes_default', 60)) * 60
+            if interval <= 0:
+                return
+            last = getattr(self, '_EtnyPoXNode__last_ipfs_cleanup_at', 0) or 0
+            if (time.time() - last) < interval:
+                return
+            self.__clear_ipfs_cache()
+        except Exception as e:
+            self.logger.warning(f"Periodic IPFS cleanup skipped: {e}")
+            self.__last_ipfs_cleanup_at = time.time()
+
     def __clear_ipfs_cache(self):
         logger = self.logger
 
         logger.info(f"Cleaning up ipfs cache")
 
-        ONE_WEEK_SECONDS = 7 * 24 * 60 * 60  # Number of seconds in one week
+        # Retention is configurable (IPFS_PIN_RETENTION_DAYS, default 7 days).
+        # 0 disables age-based cleanup entirely.
+        retention_seconds = float(getattr(config, 'ipfs_pin_retention_days_default', 7)) * 24 * 60 * 60
+        if retention_seconds <= 0:
+            logger.info("IPFS pin retention is disabled (IPFS_PIN_RETENTION_DAYS=0); skipping cleanup")
+            self.__last_ipfs_cleanup_at = time.time()
+            return
+
         current_time = time.time()
-        threshold_time = current_time - ONE_WEEK_SECONDS
-        
+
         trustedzone_images = self.__network_config.trustedzone_images.split(',')
 
         keep_hashes = []
 
         for image in trustedzone_images:
-            while True:
+            # Bounded retry: this used to loop forever on RPC failure, which was
+            # survivable at startup but would wedge the order-processing loop now
+            # that cleanup also runs periodically. On failure we skip this round
+            # -- better to keep pins one extra cycle than to stall the node.
+            for _attempt in range(5):
                 try:
                     time.sleep(self.__network_config.rpc_delay/1000)
                     [enclave_image_hash, _,
                      docker_compose_hash] = self.__image_registry.caller().getLatestTrustedZoneImageCertPublicKey(image, 'v3')
+                    keep_hashes.append(enclave_image_hash)
+                    keep_hashes.append(docker_compose_hash)
                     break
                 except Exception as e:
                     continue
+            else:
+                logger.warning(
+                    f"Could not resolve the current image hashes for {image}; skipping this cleanup "
+                    f"round so a transient RPC failure cannot unpin an image that is still in use."
+                )
+                self.__last_ipfs_cleanup_at = time.time()
+                return
 
-            keep_hashes.append(enclave_image_hash)
-            keep_hashes.append(docker_compose_hash)
-
+        retention_hours = retention_seconds / 3600
+        removed = 0
         for hash in list(self.ipfs_cache.get_values):
           if hash not in keep_hashes:
             timestamp = self.ipfs_cache.get_timestamp(hash)
             if timestamp:
                 age = current_time - timestamp
-                if age > ONE_WEEK_SECONDS:
+                if age > retention_seconds:
                     logger.debug(f"Deleting {hash} (Age: {age / 3600:.2f} hours)")
                     try:
                         self.storage.pin_rm(hash)
                         self.storage.rm(hash)
+                        removed += 1
                         logger.debug(f"Successfully deleted {hash}")
                     except Exception as e:
                         logger.debug(f"Failed to delete {hash}: {e}")
                 else:
-                    logger.debug(f"Hash {hash} is not older than one week (Age: {age / 3600:.2f} hours). Keeping pin.")
+                    logger.debug(f"Hash {hash} is within the {retention_hours:.0f}h retention (Age: {age / 3600:.2f} hours). Keeping pin.")
             else:
                 logger.warning(f"No timestamp found for {hash}. Unable to determine age. Skipping deletion.")
           else:
+            # A hash we must keep (current trustedzone image): make sure it stays
+            # pinned and refresh its cache entry so it is not aged out.
             self.storage.pin_add(hash)
             self.ipfs_cache.add(hash)
+
+        if removed:
+            logger.info(f"IPFS cleanup removed {removed} expired pin(s) (retention {retention_hours:.0f}h)")
+        self.__last_ipfs_cleanup_at = time.time()
 
     def generate_process_order_data(self, write=False):
 
@@ -1149,6 +1202,12 @@ class EtnyPoXNode:
 
             try:
                 self.__call_heart_beat()
+
+                # Reclaim expired pins. Throttled internally to at most once per
+                # IPFS_CLEANUP_INTERVAL_MINUTES, so this is a cheap timestamp
+                # check on most passes. Previously cleanup only ran at startup,
+                # so a long-lived node never reclaimed anything.
+                self.__maybe_clear_ipfs_cache()
 
                 self.storage.connect(1)
 

--- a/node/etny-node.py
+++ b/node/etny-node.py
@@ -1008,14 +1008,80 @@ class EtnyPoXNode:
         logger = self.logger
         deadline = time.time() + timeout
         logger.info(f'Checking if object {object_name} exists in bucket {bucket_name} for {timeout} seconds')
+        last_state_poll = 0
         while time.time() < deadline:
             exists, msg = self.swift_stream_service.is_object_in_bucket(bucket_name, object_name)
             if exists:
                 logger.info('Enclave execution finished!')
                 return True
+            # While waiting on the enclave, serve any ESR state it has dropped
+            # for pinning. The enclave blocks on the CID coming back, so this
+            # has to run DURING the wait, not after it. Polled every few seconds
+            # rather than every pass to keep the bucket listing cheap.
+            if self.__esr is not None and (time.time() - last_state_poll) >= 5:
+                last_state_poll = time.time()
+                self.serve_esr_state_pins(bucket_name, deadline)
             time.sleep(1)
         logger.info('Enclave execution timed out')
         return False
+
+    def serve_esr_state_pins(self, bucket_name, deadline_ts):
+        """Pin ESR state blobs the enclave drops in the bucket, and return CIDs.
+
+        The enclave cannot reach IPFS: the Kubo API binds 127.0.0.1 on the host,
+        so no container can talk to it (unlike MinIO, which is a container on the
+        ethernity network). Rather than exposing the admin API or adding a proxy,
+        the enclave writes the encrypted blob to the bucket it ALREADY uses and
+        the node pins it -- the same shape as the existing result.txt flow.
+
+        Protocol, per key:
+            enclave writes  state.<key>.enc   (encrypted state blob)
+            node pins it and writes  state.<key>.cid   (the IPFS CID)
+            enclave reads the CID and commits it on-chain
+
+        Polled alongside the task wait, until `deadline_ts`. Never raises: a
+        state pin failing must not fail the task itself.
+        """
+        served = {}
+        if not bucket_name:
+            return served
+        try:
+            objects = self.swift_stream_service.list_object_names(bucket_name) or []
+        except Exception:
+            objects = []
+        try:
+            for name in list(objects):
+                if not name or not name.startswith('state.') or not name.endswith('.enc'):
+                    continue
+                key = name[len('state.'):-len('.enc')]
+                cid_object = f'state.{key}.cid'
+                if name in served:
+                    continue
+                # Already answered for this blob: nothing to do.
+                exists, _ = self.swift_stream_service.is_object_in_bucket(bucket_name, cid_object)
+                if exists:
+                    continue
+                if time.time() > deadline_ts:
+                    self.logger.warning('Deadline reached while serving ESR state pins')
+                    break
+
+                local_path = f'{self.order_folder}/{name}'
+                ok, msg = self.swift_stream_service.download_file(bucket_name, name, local_path)
+                if not ok:
+                    self.logger.warning(f'Could not download {name} for pinning: {msg}')
+                    continue
+                cid = self.storage.upload(local_path)
+                if not cid:
+                    self.logger.warning(f'IPFS upload returned no CID for {name}')
+                    continue
+                self.storage.pin_add(cid)
+                self.ipfs_cache.add(cid)
+                self.swift_stream_service.put_file_content(bucket_name, cid_object, '', cid)
+                served[name] = cid
+                self.logger.info(f'Pinned ESR state {name} -> {cid}')
+        except Exception as e:
+            self.logger.warning(f'Serving ESR state pins failed: {e}')
+        return served
 
     def build_result_format_v1(self, result_hash, transaction_hex):
         return f'v1:{transaction_hex}:{result_hash}'

--- a/node/etny-node.py
+++ b/node/etny-node.py
@@ -1061,11 +1061,14 @@ class EtnyPoXNode:
         node can refuse to pin, or pin something else, but it cannot change what
         was committed: substitution is impossible rather than merely detectable.
 
+        That also means the enclave never waits on this: it commits as soon as it
+        has written the blob, and pinning is fire-and-forget from its point of
+        view. `deadline_ts` only bounds how long the node itself spends here.
+
         The node still verifies, so it fails loudly instead of pinning a blob
         whose CID does not match what the enclave published.
 
-        Polled alongside the task wait, until `deadline_ts`. Never raises: a
-        state pin failing must not fail the task itself.
+        Never raises: a state pin failing must not fail the task itself.
         """
         served = {}
         if not bucket_name:

--- a/node/etny-node.py
+++ b/node/etny-node.py
@@ -958,8 +958,17 @@ class EtnyPoXNode:
                 with open(f'{self.order_folder}/result.txt', 'w') as f:
                     f.write(result_data)
                 logger.debug(f'[v3] Result file successfully downloaded to {self.order_folder}/result.txt')
-                result_hash = self.upload_result_to_ipfs(f'{self.order_folder}/result.txt')
-                logger.debug(f'[v3] Result file successfully uploaded to IPFS with hash: {result_hash}')
+                # Compute the CID locally and submit on-chain immediately; the
+                # actual IPFS add/pin runs in the background and retries on its
+                # own. Previously this blocked on upload() -- 10 attempts with an
+                # IPFS restart between failures -- so a slow or unhealthy daemon
+                # could stall the submission, and after 10 failures it RAISED,
+                # losing the on-chain result for work the enclave had already
+                # completed. The stall grew with the size of the result.
+                result_hash = self.storage.pin_bytes_deferred(
+                    result_data.encode('utf-8') if isinstance(result_data, str) else result_data,
+                    name=f'result-{order_id}.txt')
+                logger.debug(f'[v3] Result CID {result_hash}; pinning in background')
                 logger.debug(f'Result file successfully uploaded to {enclave_image_name}-{v3} bucket')
                 logger.debug('Reading transaction from file')
                 status, transaction_data = self.swift_stream_service.get_file_content(bucket_name, "transaction.txt")
@@ -1115,20 +1124,15 @@ class EtnyPoXNode:
                     )
                     continue
 
-                # CIDv1 + raw-leaves so the daemon computes the SAME CID the
-                # enclave did; the default (CIDv0 dag-pb) would not match.
-                uploaded = self.storage.add_bytes_raw(blob, name=name)
-                if uploaded != declared_cid:
-                    self.logger.warning(
-                        f'ESR state {name}: IPFS stored {uploaded}, enclave published '
-                        f'{declared_cid}; not pinning'
-                    )
-                    continue
-
-                self.storage.pin_add(declared_cid)
+                # Queue the add/pin in the background and move on: a large state
+                # blob must not hold up order processing, and a temporarily
+                # unhealthy IPFS should retry rather than drop the state. The CID
+                # is already known (the enclave computed it, we verified it), so
+                # there is nothing to wait for.
+                self.storage.pin_bytes_deferred(blob, name=name)
                 self.ipfs_cache.add(declared_cid)
                 served[name] = declared_cid
-                self.logger.info(f'Pinned ESR state {name} -> {declared_cid}')
+                self.logger.info(f'ESR state {name} -> {declared_cid} (pinning in background)')
         except Exception as e:
             self.logger.warning(f'Serving ESR state pins failed: {e}')
         return served
@@ -1172,6 +1176,12 @@ class EtnyPoXNode:
                 time.sleep(5)
         
     def upload_result_to_ipfs(self, result_file):
+        """Blocking upload; kept for callers outside the v3 result path.
+
+        The v3 path now uses Storage.pin_bytes_deferred instead: this blocks for
+        up to 10 attempts with an IPFS restart between failures, and raises if
+        they all fail, which could stall or lose an on-chain result submission.
+        """
         response = self.storage.upload(result_file)
         return response
 

--- a/node/etny-node.py
+++ b/node/etny-node.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import io, os, time, json, sys, argparse, threading
+import base64, hashlib
 from types import SimpleNamespace
 from collections import defaultdict
 import concurrent.futures
@@ -1025,8 +1026,20 @@ class EtnyPoXNode:
         logger.info('Enclave execution timed out')
         return False
 
+    @staticmethod
+    def __cidv1_raw(content_bytes):
+        """CIDv1/raw/sha2-256 for `content_bytes` -- the same CID `ipfs add
+        --cid-version=1 --raw-leaves` produces.
+
+        Layout: multibase 'b' + base32( 0x01 0x55 0x12 0x20 || sha256(content) )
+                                        CIDv1 raw  sha256  32 bytes
+        """
+        digest = hashlib.sha256(content_bytes).digest()
+        raw = bytes([0x01, 0x55, 0x12, 0x20]) + digest
+        return 'b' + base64.b32encode(raw).decode('ascii').lower().rstrip('=')
+
     def serve_esr_state_pins(self, bucket_name, deadline_ts):
-        """Pin ESR state blobs the enclave drops in the bucket, and return CIDs.
+        """Pin ESR state blobs the enclave drops in the bucket.
 
         The enclave cannot reach IPFS: the Kubo API binds 127.0.0.1 on the host,
         so no container can talk to it (unlike MinIO, which is a container on the
@@ -1036,8 +1049,20 @@ class EtnyPoXNode:
 
         Protocol, per key:
             enclave writes  state.<key>.enc   (encrypted state blob)
-            node pins it and writes  state.<key>.cid   (the IPFS CID)
-            enclave reads the CID and commits it on-chain
+            enclave writes  state.<key>.cid   (the CID IT computed itself)
+            node pins the blob and confirms the CID matches its content
+
+        THE NODE NEVER SUPPLIES THE CID. The node is untrusted: if it returned
+        the CID, a malicious operator could pin the enclave's blob but hand back
+        the CID of different content, and the enclave would sign THAT onto the
+        chain -- clients would then fetch attacker-chosen state believing the
+        enclave authored it. Because a CID is a hash of the content, the enclave
+        derives it from the bytes it just encrypted and commits that. A hostile
+        node can refuse to pin, or pin something else, but it cannot change what
+        was committed: substitution is impossible rather than merely detectable.
+
+        The node still verifies, so it fails loudly instead of pinning a blob
+        whose CID does not match what the enclave published.
 
         Polled alongside the task wait, until `deadline_ts`. Never raises: a
         state pin failing must not fail the task itself.
@@ -1057,28 +1082,50 @@ class EtnyPoXNode:
                 cid_object = f'state.{key}.cid'
                 if name in served:
                     continue
-                # Already answered for this blob: nothing to do.
-                exists, _ = self.swift_stream_service.is_object_in_bucket(bucket_name, cid_object)
-                if exists:
-                    continue
                 if time.time() > deadline_ts:
                     self.logger.warning('Deadline reached while serving ESR state pins')
                     break
 
-                local_path = f'{self.order_folder}/{name}'
-                ok, msg = self.swift_stream_service.download_file(bucket_name, name, local_path)
-                if not ok:
-                    self.logger.warning(f'Could not download {name} for pinning: {msg}')
+                # The enclave publishes the CID it computed. Without it there is
+                # nothing to verify against, so wait for it rather than invent one.
+                has_cid, _ = self.swift_stream_service.is_object_in_bucket(bucket_name, cid_object)
+                if not has_cid:
                     continue
-                cid = self.storage.upload(local_path)
-                if not cid:
-                    self.logger.warning(f'IPFS upload returned no CID for {name}')
+                ok, declared_cid = self.swift_stream_service.get_file_content(bucket_name, cid_object)
+                declared_cid = (declared_cid or '').strip()
+                if not ok or not declared_cid:
                     continue
-                self.storage.pin_add(cid)
-                self.ipfs_cache.add(cid)
-                self.swift_stream_service.put_file_content(bucket_name, cid_object, '', cid)
-                served[name] = cid
-                self.logger.info(f'Pinned ESR state {name} -> {cid}')
+
+                ok, blob = self.swift_stream_service.get_file_content_bytes(bucket_name, name)
+                if not ok or blob is None:
+                    self.logger.warning(f'Could not read {name} for pinning')
+                    continue
+
+                # Confirm the enclave's CID actually describes this blob. A
+                # mismatch means the blob and the committed pointer disagree --
+                # pinning it would serve content that does not match the chain.
+                computed = self.__cidv1_raw(blob)
+                if computed != declared_cid:
+                    self.logger.warning(
+                        f'ESR state {name}: CID mismatch (enclave published {declared_cid}, '
+                        f'content hashes to {computed}); not pinning'
+                    )
+                    continue
+
+                # CIDv1 + raw-leaves so the daemon computes the SAME CID the
+                # enclave did; the default (CIDv0 dag-pb) would not match.
+                uploaded = self.storage.add_bytes_raw(blob, name=name)
+                if uploaded != declared_cid:
+                    self.logger.warning(
+                        f'ESR state {name}: IPFS stored {uploaded}, enclave published '
+                        f'{declared_cid}; not pinning'
+                    )
+                    continue
+
+                self.storage.pin_add(declared_cid)
+                self.ipfs_cache.add(declared_cid)
+                served[name] = declared_cid
+                self.logger.info(f'Pinned ESR state {name} -> {declared_cid}')
         except Exception as e:
             self.logger.warning(f'Serving ESR state pins failed: {e}')
         return served

--- a/node/etny-node.py
+++ b/node/etny-node.py
@@ -302,13 +302,14 @@ class EtnyPoXNode:
     def __looks_like_cid(value):
         """True for values that plausibly are IPFS CIDs.
 
-        The ESR stores the pointer as an unvalidated string, so the live
-        registry does contain non-CID entries (a 0x-prefixed digest, for
-        instance). Filtering here keeps them out of pin/add, which would
-        otherwise error on every cleanup pass.
+        The contract accepts any non-empty string as the pointer, so a buggy
+        writer can commit something that is not a CID at all -- the live registry
+        currently has one entry holding a 0x… digest. That is a defect in
+        whatever wrote it, NOT a format to support: such entries are skipped and
+        logged, never pinned. Handing one to pin/add errors on every cleanup
+        pass, and a client would retry-loop on it forever.
 
-        CIDv0 is 46 chars starting "Qm"; CIDv1 is base32 starting "b". Anything
-        0x-prefixed is definitely not a CID.
+        CIDv0 is 46 chars starting "Qm"; CIDv1 is base32 starting "b".
         """
         cid = (value or "").strip()
         if not cid or cid.startswith("0x"):
@@ -353,6 +354,15 @@ class EtnyPoXNode:
                     # to pin/add just produces errors on every cleanup pass.
                     if version and self.__looks_like_cid(cid):
                         cids.add(cid)
+                    elif version and cid:
+                        # A committed pointer that is not a CID means the writer
+                        # is buggy. Say so once per pass rather than skipping in
+                        # silence -- otherwise the defect stays invisible.
+                        self.logger.warning(
+                            f"ESR entry for {enclave}/{key.hex()[:10]}… is not a valid CID "
+                            f"({cid[:24]}…); skipping. The committing enclave is writing a "
+                            f"non-CID pointer."
+                        )
                 except Exception as e:
                     self.logger.debug(f"ESR getState failed for {enclave}/{key.hex()}: {e}")
 

--- a/node/swift_stream_service.py
+++ b/node/swift_stream_service.py
@@ -249,6 +249,25 @@ class SwiftStreamService:
                 return False, err
 
 
+    def list_object_names(self, bucket_name: str) -> list:
+        """Object names in a bucket, or [] on failure.
+
+        _list_objects below only PRINTS and returns None, so it cannot be used
+        programmatically. This is the callable variant (used to find the ESR
+        state blobs an enclave has dropped for the node to pin).
+        """
+        try:
+            return [obj.object_name for obj in self.client.list_objects(bucket_name)]
+        except S3Error as err:
+            if self.restart_etny_swift_stream_and_reconnect():
+                try:
+                    return [obj.object_name for obj in self.client.list_objects(bucket_name)]
+                except S3Error:
+                    return []
+            return []
+        except Exception:
+            return []
+
     def _list_buckets(self) -> None:
         try:
             buckets = self.client.list_buckets()

--- a/node/swift_stream_service.py
+++ b/node/swift_stream_service.py
@@ -238,9 +238,12 @@ class SwiftStreamService:
         try:
             self.client.stat_object(bucket_name, object_name)
             return True, f"{object_name} exists in {bucket_name}."
-            return False, f"{object_name} does not exist in {bucket_name}."
         except S3Error as err:
-            if err.code == "NoSuchKey":
+            # "Absent" is a normal answer, not a fault: NoSuchKey is the object
+            # missing, NoSuchBucket the bucket. Neither means the service is
+            # unhealthy, so neither should trigger a MinIO restart -- that used
+            # to happen for a missing bucket and cost a restart per call.
+            if err.code in ("NoSuchKey", "NoSuchBucket"):
                 return False, f"{object_name} does not exist in {bucket_name}."
 
             if self.restart_etny_swift_stream_and_reconnect():
@@ -280,15 +283,13 @@ class SwiftStreamService:
                 print(f"_list_buckets failed: {err}")
 
     def _list_objects(self, bucket_name: str) -> None:
-        try:
-            objects = self.client.list_objects(bucket_name)
-            for obj in objects:
-                print("-> ", obj.object_name, obj.owner_name)
-        except S3Error as err:
-            if self.restart_etny_swift_stream_and_reconnect():
-                return self._list_objects(bucket_name)
-            else:
-                print(f"_list_objects failed: {err}")
+        """Debug helper: PRINTS the objects in a bucket and returns nothing.
+
+        Use list_object_names() to actually get the names -- this one is for
+        eyeballing state during development only.
+        """
+        for name in self.list_object_names(bucket_name):
+            print("-> ", name)
 
     def _is_bucket(self, bucket_name: str) -> bool:
         try:

--- a/node/utils.py
+++ b/node/utils.py
@@ -675,6 +675,32 @@ class Storage:
             time.sleep(1)
         raise Exception(f"Unable to determine if {path} is file or folder after 10 attempts")
 
+    def add_bytes_raw(self, content_bytes, name='blob'):
+        """Add bytes as CIDv1 with raw leaves, returning the CID.
+
+        The default `add` produces a CIDv0 dag-pb node (content wrapped in UnixFS
+        framing), whose CID an enclave cannot derive without reimplementing that
+        framing. With cid-version=1 + raw-leaves the CID is simply
+        base32(0x01 0x55 0x12 0x20 || sha256(content)) -- so the enclave can
+        compute it from the bytes it authored and commit THAT to the chain,
+        meaning a hostile node cannot substitute different content for what was
+        committed.
+
+        Returns the CID, or None on failure.
+        """
+        if not self.connected:
+            raise Exception("Not connected")
+        files = {'file': (name, content_bytes)}
+        params = {'cid-version': '1', 'raw-leaves': 'true', 'pin': 'true'}
+        resp = self._api_call('add', params=params, files=files)
+        try:
+            if isinstance(resp, str):
+                resp = json.loads(resp.strip().split('\n')[-1])
+            return resp.get('Hash')
+        except Exception as e:
+            self.logger.warning(f"Could not parse add response for {name}: {e}")
+            return None
+
     def add_path(self, path):
         if not self.connected:
             raise Exception("Not connected")

--- a/node/utils.py
+++ b/node/utils.py
@@ -20,6 +20,8 @@ aches/files during upgrades without unpinning (as upgrade handles it).
 """
 
 from asyncio.log import logger
+import base64
+import hashlib
 import json
 import os
 import io
@@ -674,6 +676,64 @@ class Storage:
                 self.logger.debug(f"Attempt {attempt+1} failed to check if folder: {e}")
             time.sleep(1)
         raise Exception(f"Unable to determine if {path} is file or folder after 10 attempts")
+
+    @staticmethod
+    def cidv1_raw(content_bytes):
+        """CIDv1/raw/sha2-256 for `content_bytes`, computed locally.
+
+        Layout: 'b' + base32( 0x01 0x55 0x12 0x20 || sha256(content) )
+                        CIDv1  raw  sha256  32 bytes
+
+        Matches what `ipfs add --cid-version=1 --raw-leaves` returns, so the CID
+        can be known WITHOUT talking to IPFS at all. That is what lets the node
+        record a result and move on while pinning happens in the background.
+        """
+        digest = hashlib.sha256(content_bytes).digest()
+        raw = bytes([0x01, 0x55, 0x12, 0x20]) + digest
+        return 'b' + base64.b32encode(raw).decode('ascii').lower().rstrip('=')
+
+    def pin_bytes_deferred(self, content_bytes, name='blob', attempts=10, delay=30):
+        """Compute the CID now, return it, and pin in the BACKGROUND.
+
+        `upload()` blocks for up to 10 attempts with an IPFS service restart
+        between failures, and raises if they all fail. On the result path that
+        meant a slow or unhealthy IPFS could stall -- or lose -- an on-chain
+        result submission for work the enclave had already completed correctly,
+        and the stall grows with the size of the result.
+
+        Since the CID is just a hash of the content, it can be computed locally.
+        The caller gets it immediately and proceeds; the actual add/pin is queued
+        on the existing executor and retries on its own without holding anything
+        up.
+
+        Returns the CID (never None, never raises).
+        """
+        cid = self.cidv1_raw(content_bytes)
+
+        def _work():
+            for attempt in range(attempts):
+                try:
+                    stored = self.add_bytes_raw(content_bytes, name=name)
+                    if stored == cid:
+                        self.cache.add(cid)
+                        self.logger.info(f"Pinned {name} -> {cid} (background)")
+                        return
+                    self.logger.warning(
+                        f"Background pin of {name}: IPFS stored {stored}, expected {cid}")
+                    return
+                except Exception as e:
+                    self.logger.warning(
+                        f"Background pin attempt {attempt + 1}/{attempts} for {name} failed: {e}")
+                    time.sleep(delay)
+            self.logger.error(f"Background pin of {name} ({cid}) failed after {attempts} attempts")
+
+        try:
+            self.executor.submit(_work)
+        except Exception as e:
+            # Even losing the worker must not fail the caller: the CID is valid
+            # regardless, and other nodes replicate from the registry/chain.
+            self.logger.warning(f"Could not queue background pin for {name}: {e}")
+        return cid
 
     def add_bytes_raw(self, content_bytes, name='blob'):
         """Add bytes as CIDv1 with raw leaves, returning the CID.


### PR DESCRIPTION
IPFS pin retention controls + ESR state replication.

**Pin retention** — the 7-day expiry was hardcoded and only ran at startup, so long-lived nodes never reclaimed anything. Now `IPFS_PIN_RETENTION_DAYS` (default 7) and `IPFS_CLEANUP_INTERVAL_MINUTES` (default 60), running periodically from the order loop.

**State replication** — nodes pin the state enclaves publish to the registry, so a dApp doesn't depend on the node that produced it. Current versions are protected from expiry, superseded ones age out. Stops below `ESR_MIN_FREE_STORAGE_GB` (10GB). Networks without an ESR skip it entirely.

**The enclave computes its own CID** — the node is untrusted, so it must not supply the CID: it could pin the enclave's blob and return the CID of different content, which the enclave would then sign onto the chain. Since a CID is a hash of the content, the enclave derives it from the bytes it encrypted and commits that. The node pins and verifies, never dictates — substitution is impossible rather than merely detectable, and the enclave never waits on the node.

```
enclave writes  state.<key>.enc + state.<key>.cid
node pins the blob and confirms the CID matches
```

Uses CIDv1 + raw-leaves, where the CID is `base32(0x01 0x55 0x12 0x20 || sha256(content))` — computable inside the enclave. The default CIDv0 wraps content in dag-pb framing that the enclave would have to reimplement. Verified byte-exact against the IPFS daemon.

Latent bugs fixed:
- Unbounded RPC retry that would have wedged the order loop
- `is_object_in_bucket` had unreachable code and restarted MinIO on a missing bucket
- `_list_objects` only printed and returned `None`; added `list_object_names`
- The registry stores CIDs with no format check — one live entry is a `0x…` digest, now filtered before `pin/add`
